### PR TITLE
fixes for Adult Swim site updates and metadata collection

### DIFF
--- a/resources/lib/metahandler.py
+++ b/resources/lib/metahandler.py
@@ -419,7 +419,11 @@ class MetaData:
                 meta['title'] = name
                 if str(show.rating) != '' and show.rating is not None:
                     meta['rating'] = float(show.rating)
-                meta['duration'] = int(show.runtime) * 60
+                # "Soft Focus with Jena Friedman" had an empty runtime, killing metadata routines
+                if str(show.runtime) != '':
+                    meta['duration'] = int(show.runtime) * 60
+                else:
+                    meta['duration'] = 99999 # not sure whether '0' would cause future issues
                 meta['plot'] = show.overview
                 meta['mpaa'] = show.content_rating
                 meta['premiered'] = str(show.first_aired)

--- a/resources/lib/scraper.py
+++ b/resources/lib/scraper.py
@@ -22,9 +22,11 @@ class myAddon(t1mAddon):
     def getAddonMenu(self, url, ilist):
         xbmcplugin.setContent(int(sys.argv[1]), 'tvshows')
         response = self.getRequest('http://www.adultswim.com/videos')
-        shows = re.search("""__AS_INITIAL_DATA__\s*=\s*({.*?});""", response).groups()[0]
+#       shows = re.search("""__AS_INITIAL_DATA__\s*=\s*({.*?});""", response).groups()[0]
+        shows = re.search("""__AS_INITIAL_STATE__\s*=\s*({.*?})</script>""", response).groups()[0]		
         shows = json.loads(shows.replace("\/", "/"))
-        shows = shows["shows"]
+#       shows = shows["shows"]
+        shows = shows["showsIndex"]["shows"]
         getmeta = xbmcaddon.Addon().getSetting("getmeta")
 
         blacklist = ["live simulcast", "music videos", "on cinema", "promos", "shorts", 'williams street swap shop',


### PR DESCRIPTION
fixes for 2 issues I submitted:

regex and json response formats have changed. fixed in scraper.py. (issue #18)

metadata collection was broken by a show that had no integer runtime. fixed in metahandler.py. (issue #16)